### PR TITLE
Added infix pattern synonym for 'App'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ firmware/EEPROMErase/build-*
 
 # Mac Files
 .DS_Store
+
+# Editor temporary files
+.*.swp

--- a/System/Hardware/Haskino/ShallowDeepPlugin/AbsLambdaPass.hs
+++ b/System/Hardware/Haskino/ShallowDeepPlugin/AbsLambdaPass.hs
@@ -69,7 +69,7 @@ changeLambdaExpr e = do
     -- Look for expressions of the form:  
     -- forall (m :: Arduino a) (F :: a -> Arudino b)
     -- m >>= (\x -> F[x])
-    App (App (App (App (App (App (Var bind) (Type monadTy)) dict) (Type arg1Ty)) (Type arg2Ty)) e_right) (Lam b e_lam) | bind == bindId -> do
+    (Var bind) :$ (Type monadTy) :$ dict :$ (Type arg1Ty) :$ (Type arg2Ty) :$ e_right :$ (Lam b e_lam) | bind == bindId -> do
         -- Check if the right hand side of the bind operations end
         -- in monadic function with abs_ applied to it.  In other words
         -- m >>= m1 >>= ... >>= abs_ <$> mn 
@@ -104,9 +104,9 @@ changeLambdaExpr e = do
             newb <- buildId ((varString b) ++ "_abs") exprArg1Ty
             absId <- thNameToId absNameTH
             e_lam'' <- subVarExpr b (App (App (Var absId) (Type arg1Ty)) (Var newb)) e_lam'
-            return $ App (App (App (App (App (App (Var bind) (Type monadTy)) dict) (Type exprArg1Ty)) (Type arg2Ty)) e_right'') (Lam newb e_lam'')
+            return ((Var bind) :$ (Type monadTy) :$ dict :$ (Type exprArg1Ty) :$ (Type arg2Ty) :$ e_right'' :$ (Lam newb e_lam''))
         else do
-            return $ App (App (App (App (App (App (Var bind) (Type monadTy)) dict) (Type arg1Ty)) (Type arg2Ty)) e_right'') (Lam b e_lam')
+            return ((Var bind) :$ (Type monadTy) :$ dict :$ (Type arg1Ty) :$ (Type arg2Ty) :$ e_right'' :$ (Lam b e_lam'))
     App e1 e2 -> do
       e1' <- changeLambdaExpr e1
       e2' <- changeLambdaExpr e2

--- a/System/Hardware/Haskino/ShallowDeepPlugin/Utils.hs
+++ b/System/Hardware/Haskino/ShallowDeepPlugin/Utils.hs
@@ -89,7 +89,7 @@ returnNameTH         = 'Prelude.return
 
 -- An infix pattern synonym for `App` to make applications with multiple
 -- arguments easier to manipulate:
-infixr 0 :$
+infixl 0 :$
 pattern f :$ x = App f x
 
 class (Monad m, MonadIO m) => PassCoreM m where

--- a/System/Hardware/Haskino/ShallowDeepPlugin/Utils.hs
+++ b/System/Hardware/Haskino/ShallowDeepPlugin/Utils.hs
@@ -9,6 +9,7 @@
 -------------------------------------------------------------------------------
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE PatternSynonyms #-}
 module System.Hardware.Haskino.ShallowDeepPlugin.Utils (absExpr,
                                            buildDictionaryT,
                                            buildDictionaryTyConT,
@@ -23,6 +24,7 @@ module System.Hardware.Haskino.ShallowDeepPlugin.Utils (absExpr,
                                            thNameTyToDict,
                                            thNameTyToTyConApp,
                                            PassCoreM(..),
+                                           pattern (:$),
                                            -- DSL specific names
                                            exprClassTyConTH,
                                            exprTyConTH,
@@ -84,6 +86,11 @@ bindThenNameTH       = '(>>)
 falseNameTH          = 'Prelude.False
 fmapNameTH           = '(<$>)
 returnNameTH         = 'Prelude.return
+
+-- An infix pattern synonym for `App` to make applications with multiple
+-- arguments easier to manipulate:
+infixr 0 :$
+pattern f :$ x = App f x
 
 class (Monad m, MonadIO m) => PassCoreM m where
     -- | 'CoreM' can be lifted to this monad.


### PR DESCRIPTION
Does this look ok? I had this when I was trying to make a GHC plugin. It allows you to avoid deeply nesting parentheses when matching on/constructing function applications with multiple arguments.

Note that it associates a bit differently than `($)` (it associates in the opposite direction). It's just that, for now, `(:$)` is the best name I can think of. So something like

```
f :$ x :$ y
```

is identical to

```
App (App f x) y
```